### PR TITLE
increment version for publishing gem

### DIFF
--- a/lib/omniauth/xero/version.rb
+++ b/lib/omniauth/xero/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Xero
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
Could this be gem be republished as 1.0.1? The current 1.0.0 gem does not include the last 2 commits in master.