### PR TITLE
Allow organization without any subscribers to get authorized.

### DIFF
--- a/lib/omniauth/strategies/xero.rb
+++ b/lib/omniauth/strategies/xero.rb
@@ -29,7 +29,7 @@ module OmniAuth
       private
 
       def raw_info
-        @raw_info ||= users.find { |user| user["IsSubscriber"] }
+        @raw_info ||= users.find { |user| user["IsSubscriber"] } || users.first
       end
 
       def users

--- a/spec/omniauth/strategies/xero_spec.rb
+++ b/spec/omniauth/strategies/xero_spec.rb
@@ -22,4 +22,10 @@ describe "OmniAuth::Strategies::Xero" do
       expect(subject.options.client_options.authorize_path).to eq('/oauth/Authorize')
     end
   end
+
+  context 'organization with no subscriber' do
+    it 'gets authorized' do
+      expect(subject.raw_info).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
I tried to authorize my Demo Company locally and was not able due to `@raw_info` being `nil`. This bypasses the need for a subscriber. 
I first saw it on this [repo](https://github.com/unboxed/omniauth-xero/commit/78fb235a8e68fb189f593a0b21ec28e86c10f367)
